### PR TITLE
Fix kconfig include file path, include guard and .eBuild.config section.

### DIFF
--- a/helpers.mk
+++ b/helpers.mk
@@ -101,7 +101,7 @@ $(strip $($(1)-ldflags) $(call pkgconfig_ldflags,$($(1)-pkgconf)))
 endef
 
 define obj_includes
-$(strip $(if $(kconf_head),-I$(abspath $(kconf_head)/../..)) \
+$(strip $(if $(kconf_head),-I$(abspath $(kconf_autoconf)/../include)) \
         -iquote $(dir $(1)) \
         -iquote $(dir $(2)) \
         $(if $(HEADERDIR),-iquote $(HEADERDIR)) \

--- a/helpers.mk
+++ b/helpers.mk
@@ -45,6 +45,10 @@ define toupper
 $(shell echo '$(1)' | tr '[:lower:]' '[:upper:]')
 endef
 
+define toincguard
+$(call toupper,$(shell echo '$(1)' | tr '-' '_'))
+endef
+
 define rm_recipe
 @echo "  RM      $(strip $(1))"
 $(Q)$(RM) $(1)

--- a/main.mk
+++ b/main.mk
@@ -97,12 +97,12 @@ $(kconf_autohead): | $(kconfdir)
 $(kconf_head): $(kconf_autohead) $(ebuild_deps) | $(dir $(kconf_head))
 	$(Q):; > $(@); \
 	    exec >> $(@); \
-	    echo '#ifndef _$(call toupper,$(PACKAGE))_CONFIG_H'; \
-	    echo '#define _$(call toupper,$(PACKAGE))_CONFIG_H'; \
+	    echo '#ifndef _$(call toincguard,$(PACKAGE))_CONFIG_H'; \
+	    echo '#define _$(call toincguard,$(PACKAGE))_CONFIG_H'; \
 	    echo; \
 	    grep '^#define' $(<); \
 	    echo; \
-	    echo '#endif /* _$(call toupper,$(PACKAGE))_CONFIG_H */'
+	    echo '#endif /* _$(call toincguard,$(PACKAGE))_CONFIG_H */'
 
 .PHONY: menuconfig
 menuconfig: | $(kconfdir)

--- a/main.mk
+++ b/main.mk
@@ -34,7 +34,7 @@ kconf_config := $(BUILDDIR)/.config
 
 ifdef config-in
 
-kconf_head   := $(BUILDDIR)/include/$(PACKAGE)/config.h
+kconf_head   := $(BUILDDIR)/include/$(config-h)
 all_deps     := $(kconf_head)
 
 config-in    := $(CURDIR)/$(config-in)

--- a/scripts/gen_conf_obj_src.sh
+++ b/scripts/gen_conf_obj_src.sh
@@ -31,7 +31,9 @@ cat - << _EOF
 
 static EBUILD_CONFIG(__ebuild_config) =
 $(sed --silent \
-      '/^#.*/d; :p; s/\\/\\\\/g; s/"/\\"/g; s/^\(.*\)$/"\1\\0"/p; n; bp' \
+      --expression='/^# Automatically generated file; DO NOT EDIT.$/d' \
+      --expression='/^# Configuration$/d' \
+      --expression=':p; /^[#]*$/d; s/\\/\\\\/g; s/"/\\"/g; s/^\(.*\)$/"\1\\0"/p; n; bp' \
       $kconf_path)
 ;
 _EOF


### PR DESCRIPTION
3 Fix:
- sed regex in gen_conf_obj_src.sh to add all config and real comment in .eBuild.config section.
- config.h include guard to use PACKAGE with '-' character.
- kconfig header path to use same path in build and install step.